### PR TITLE
Keccak256 - String as parameter

### DIFF
--- a/syntax/solidity.vim
+++ b/syntax/solidity.vim
@@ -215,7 +215,7 @@ hi def link   solAssemblyCond     Conditional
 
 " Builtin Methods
 syn keyword   solMethod           delete new var return import
-syn region    solMethodParens     start='(' end=')' contained transparent
+syn region    solMethodParens     start='(' end=')' contains=solString contained transparent
 syn keyword   solMethod           nextgroup=solMethodParens skipwhite skipempty
       \ blockhash require revert assert keccak256 sha256
       \ ripemd160 ecrecover addmod mullmod selfdestruct


### PR DESCRIPTION
The problem is when using keccak256 in the contract definition the plugin is not escaping correctly if inside is another pair of ().

Example:

`contract A {
   bytes32 a = keccak256("FUNC(uint a, uint b)");
}` 