### PR TITLE
Add spelling regions: comments, natspec, strings

### DIFF
--- a/syntax/solidity.vim
+++ b/syntax/solidity.vim
@@ -55,8 +55,8 @@ syntax match  solNumber           '\v\c<%(\d+%(e[+-]=\d+)=|0b[01]+|0o\o+|0x\x+)>
 syntax match  solNumber           '\v\c<%(\d+.\d+|\d+.|.\d+)%(e[+-]=\d+)=>'
 
 " Strings
-syntax region solString           start=/\v"/ skip=/\v\\./ end=/\v"/
-syntax region solString           start="\v'" skip="\v\\." end="\v'"
+syntax region solString           start=/\v"/ skip=/\v\\./ end=/\v"/ contains=@Spell
+syntax region solString           start="\v'" skip="\v\\." end="\v'" contains=@Spell
 
 hi def link   solNumber           Number
 hi def link   solString           String
@@ -300,8 +300,8 @@ hi def link   solLoop             Keyword
 
 " Comments
 syn keyword   solTodo             TODO FIXME XXX TBD contained
-syn region    solComment          start=/\/\// end=/$/ contains=solTodo
-syn region    solComment          start=/\/\*/ end=/\*\// contains=solTodo
+syn region    solComment          start=/\/\// end=/$/ contains=solTodo,@Spell
+syn region    solComment          start=/\/\*/ end=/\*\// contains=solTodo,@Spell
 
 hi def link   solTodo             Todo
 hi def link   solComment          Comment
@@ -314,8 +314,8 @@ syn match     solNatspecTag       /@notice\>/ contained
 syn match     solNatspecTag       /@param\>/ contained
 syn match     solNatspecTag       /@return\>/ contained
 syn match     solNatspecParam     /\(@param\s*\)\@<=\<[a-zA-Z_][0-9a-zA-Z_]*/
-syn region    solNatspecBlock     start=/\/\/\// end=/$/ contains=solTodo,solNatspecTag,solNatspecParam
-syn region    solNatspecBlock     start=/\/\*\{2}/ end=/\*\// contains=solTodo,solNatspecTag,solNatspecParam
+syn region    solNatspecBlock     start=/\/\/\// end=/$/ contains=solTodo,solNatspecTag,solNatspecParam,@Spell
+syn region    solNatspecBlock     start=/\/\*\{2}/ end=/\*\// contains=solTodo,solNatspecTag,solNatspecParam,@Spell
 
 hi def link   solNatspecTag       SpecialComment
 hi def link   solNatspecBlock     Comment


### PR DESCRIPTION
Currently, the highlighting is totally broken if you have `:set spell` on, since everything is spellchecked. This is a regression from the original tomlion/vim-solidity,

This PR specifies the syntax highlighting should only be done within comments and strings.